### PR TITLE
Scanner Name Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See https://github.com/target/strelka for more information.
 # Note: This is just used for initial launch. Not needed afterwards.
 # Depending on your environment, you may need additional packages:
 # sudo apt-get install build-essential python3-dev libpq-dev python3-dev gcc python3-dev musl-dev libffi-dev cargo
-$ python3 -m venv env
+$ virtualenv env
 $ source env/bin/activate
 $ pip3 install -r app/requirements.txt
 

--- a/ui/src/components/ScanDisplayCard.js
+++ b/ui/src/components/ScanDisplayCard.js
@@ -9,9 +9,11 @@ const ScanDisplayCard = ({ scanner_name, data }) => {
   const [expanded, setExpanded] = useState(false);
 
   const item_key = scanner_name
-    .match(/[A-Z][a-z]+/g)
+    .match(/[A-Z][a-z]+([0-9][a-z]+)?/g)
     .map((v) => v.toLowerCase())
     .slice(0, 3)[1]
+
+   const scanner_key = "scan_" + item_key
 
   return (
     <div style={{ width: "100%" }}>
@@ -26,7 +28,7 @@ const ScanDisplayCard = ({ scanner_name, data }) => {
         <div>
           <Typography>
             <Title level={5}>{scanner_name}</Title>
-            <Text>Took {data["scan"][item_key].elapsed} seconds</Text>
+            <Text>Took {data[scanner_key].elapsed} seconds</Text>
           </Typography>
         </div>
         <div>
@@ -41,7 +43,7 @@ const ScanDisplayCard = ({ scanner_name, data }) => {
             <br />
         <DataDisplayObj
           value={
-            data["scan"][item_key]
+            data[scanner_key]
           }
         />
         </div>


### PR DESCRIPTION
PR implemented to fix #15 

Issue when loading records with scanners that included digits in their names.

For example, `ScanXl4ma` would break on `4` as a regular expression would fail to parse the Scanner name properly.
This fix adds in support for potential digits in the scanner name.