### PR TITLE
Implement Docker Image Publishing on New Tag Creation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,45 @@
+name: Publish Latest Images to Docker Hub
+
+on:
+  push:
+    branches: [publish-images-all]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Action Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build, Tag, and Push Image
+        run: |
+          # Enable Docker BuildKit
+          export DOCKER_BUILDKIT=1
+          
+          # Set tag variables
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          TAG_NAME=$(git describe --tags --abbrev=0)
+          
+          # Image details
+          IMAGE_NAME="target/strelka-ui"
+          DOCKERFILE_PATH="./Dockerfile"
+          
+          # Build, tag, and push image
+          docker build -f "${DOCKERFILE_PATH}" -t "${IMAGE_NAME}:${COMMIT_HASH}" -t "${IMAGE_NAME}:${TAG_NAME}" -t "${IMAGE_NAME}:latest" .
+          docker push "${IMAGE_NAME}:${COMMIT_HASH}"
+          docker push "${IMAGE_NAME}:${TAG_NAME}"
+          docker push "${IMAGE_NAME}:latest"
+          
+      - name: Logout from Docker Hub
+        run: docker logout


### PR DESCRIPTION
**Describe the change**
This pull request includes changes to our GitHub Actions workflow, specifically targeting the process of building and pushing our Docker image. The new workflow will trigger whenever a new tag is created in the repository.

Images are now being pushed to `https://hub.docker.com/u/target/strelka-ui`

**Changes Include:**
- The workflow is now triggered on tag creation.
- Pushes to new repository

**The updated workflow:**
1. Checks out the repository.
2. Logs in to Docker Hub.
3. Builds, tags, and pushes Docker image.
4. Logs out from Docker Hub.

**Describe testing procedures**
N/A

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
