### PR TITLE
Updating docker compose v1 to v2

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Builds Strelka
-        run: docker-compose build
+        run: docker compose build

--- a/.github/workflows/build_strelkaui_daily.yml
+++ b/.github/workflows/build_strelkaui_daily.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Builds Strelka UI
-        run: docker-compose build
+        run: docker compose build


### PR DESCRIPTION
## Description
The nightly build has been failing for several days due to the depreciation of docker-compose v1. This PR converts the git workflows to use v2. Tested locally with docker build. 