### PR TITLE
update colors to use antd theme tokens

### DIFF
--- a/ui/src/components/FileFlow/EdgeTypes/IndexConnectEdge.tsx
+++ b/ui/src/components/FileFlow/EdgeTypes/IndexConnectEdge.tsx
@@ -6,15 +6,14 @@ import {
 } from '@xyflow/react'
 import { theme } from 'antd'
 import styled from 'styled-components'
-import { antdColors } from '../../../utils/colors'
 
 const { useToken } = theme
 
-const EdgeLabel = styled.div<{ $markerColor: string }>`
+const EdgeLabel = styled.div<{ $markerColor: string; $greyLight: string }>`
   position: absolute;
   transform: translate(-50%, -50%);
   font-size: 11px;
-  font-weight: ${(props) => (props.$markerColor !== antdColors.lightGray ? '700' : '500')};
+  font-weight: ${(props) => (props.$markerColor !== props.$greyLight ? '700' : '500')};
   line-height: 12px;
   padding: 2px 4px;
   border-radius: 3px;
@@ -61,7 +60,7 @@ export function IndexConnectEdge({
   const { token } = useToken()
 
   const markerColor = isHighlighted
-    ? antdColors.darkGray
+    ? token.colorTextSecondary
     : (style.stroke as string)
 
   return (
@@ -85,6 +84,7 @@ export function IndexConnectEdge({
           }}
           className="nodrag nopan"
           $markerColor={markerColor}
+          $greyLight={token.colorTextSecondary}
         >
           {label}
         </EdgeLabel>

--- a/ui/src/components/FileFlow/FileTreeCard.tsx
+++ b/ui/src/components/FileFlow/FileTreeCard.tsx
@@ -12,6 +12,7 @@ import {
   useNodesState,
   useReactFlow,
 } from '@xyflow/react'
+import { theme } from 'antd'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { IndexConnectEdge } from './EdgeTypes/IndexConnectEdge'
 import EventNode from './NodeTypes/EventNode'
@@ -21,7 +22,6 @@ import DownloadImage from '../../utils/DownloadImage'
 import ExceededGuide from '../../utils/ExceededGuide'
 import NodeSearchPanel from '../../utils/NodeSearchPanel'
 import ShowFileListing from '../../utils/ShowFileListing'
-import { antdColors } from '../../utils/colors'
 import { getDagreLayout } from '../../utils/dagreLayout'
 import {
   toggleChildrenVisibility,
@@ -30,7 +30,10 @@ import {
 
 import { useDarkModeSetting } from '../../hooks/useDarkModeSetting'
 import type { StrelkaResponse } from '../../services/api.types'
+import { useIconConfig } from '../../utils/iconMappingTable.js'
 import type { StrelkaNodeData } from '../../utils/indexDataUtils'
+
+const { useToken } = theme
 
 const nodeTypes = {
   event: EventNode,
@@ -64,6 +67,7 @@ const FileTreeCard = (props: FileTreeCardProps) => {
     selectedNodeData,
     setSelectedNodeData,
   } = props
+  const { token } = useToken()
   const [searchTerm, setSearchTerm] = useState('')
   const { fitView } = useReactFlow()
 
@@ -80,6 +84,8 @@ const FileTreeCard = (props: FileTreeCardProps) => {
 
   const [highlightedEdge, setHighlightedEdge] = useState(null)
   const [highlightedNode, setHighlightedNode] = useState(null)
+
+  const { getIconConfig } = useIconConfig()
 
   useEffect(() => {
     const vtExceeded = data.some((item) => {
@@ -219,7 +225,9 @@ const FileTreeCard = (props: FileTreeCardProps) => {
       ...edge,
       style: {
         ...edge.style,
-        stroke: isHighlighted ? antdColors.darkGray : antdColors.lightGray,
+        stroke: isHighlighted
+          ? token.colorTextSecondary
+          : token.colorTextTertiary,
         strokeWidth: isHighlighted ? 2 : 2,
       },
       data: { ...edge.data, isHighlighted },
@@ -241,7 +249,7 @@ const FileTreeCard = (props: FileTreeCardProps) => {
 
   useEffect(() => {
     const { nodes: transformedNodes, edges: transformedEdges } =
-      transformElasticSearchDataToElements(data)
+      transformElasticSearchDataToElements(data, getIconConfig)
 
     const nodesToLayout = transformedNodes.filter(isNode)
     const edgesToLayout = transformedEdges.filter((el) => !isNode(el))
@@ -250,7 +258,7 @@ const FileTreeCard = (props: FileTreeCardProps) => {
 
     setNodes(layoutedData.filter(isNode) as Node<StrelkaNodeData>[])
     setEdges(layoutedData.filter((el) => !isNode(el)) as Edge[])
-  }, [data, setEdges, setNodes])
+  }, [data, setEdges, setNodes, getIconConfig])
 
   const { isDarkMode } = useDarkModeSetting()
   const colorMode = isDarkMode ? 'dark' : 'light'

--- a/ui/src/components/FileFlow/NodeTypes/EventNode.tsx
+++ b/ui/src/components/FileFlow/NodeTypes/EventNode.tsx
@@ -8,8 +8,7 @@ import { Handle, Position } from '@xyflow/react'
 import { Tag, Tooltip, theme } from 'antd'
 import { memo, useEffect, useState } from 'react'
 import styled, { createGlobalStyle } from 'styled-components'
-import { antdColors } from '../../../utils/colors'
-import { getIconConfig } from '../../../utils/iconMappingTable'
+import { useIconConfig } from '../../../utils/iconMappingTable'
 import type { StrelkaNodeData } from '../../../utils/indexDataUtils'
 
 const { useToken } = theme
@@ -34,15 +33,18 @@ function lightenHexColor(hexColor: string, factor: number): string {
 }
 
 // Styled Components
-const LockIndicatorWrapper = styled.div`
+const LockIndicatorWrapper = styled.div<{
+  $bgColor?: string
+  $borderColor?: string
+}>`
   position: absolute;
   bottom: 10px;
   right: 15px;
   width: 24px;
   height: 24px;
   border-radius: 4px;
-  border: 1px solid ${antdColors.red};
-  background: ${antdColors.lightRed};
+  border: 1px solid ${({ $borderColor }) => $borderColor || 'transparent'};
+  background: ${({ $bgColor }) => $bgColor || 'transparent'};
   box-shadow: 0px 4px 6px -1px rgba(0, 0, 0, 0.1),
     0px 2px 4px -1px rgba(0, 0, 0, 0.06);
   display: flex;
@@ -51,15 +53,18 @@ const LockIndicatorWrapper = styled.div`
   cursor: pointer;
 `
 
-const UnlockIndicatorWrapper = styled.div`
+const UnlockIndicatorWrapper = styled.div<{
+  $bgColor?: string
+  $borderColor?: string
+}>`
   position: absolute;
   bottom: 10px;
   right: 15px;
   width: 24px;
   height: 24px;
   border-radius: 4px;
-  border: 1px solid ${antdColors.darkGreen};
-  background: ${antdColors.lightGreen};
+  border: 1px solid ${(props) => props.$borderColor};
+  background: ${(props) => props.$bgColor};
   box-shadow: 0px 4px 6px -1px rgba(0, 0, 0, 0.1),
     0px 2px 4px -1px rgba(0, 0, 0, 0.06);
   display: flex;
@@ -68,14 +73,17 @@ const UnlockIndicatorWrapper = styled.div`
   cursor: pointer;
 `
 
-const QrCodePreviewWrapper = styled.div<{ hasImage: boolean }>`
+const QrCodePreviewWrapper = styled.div<{
+  hasImage: boolean
+  $bgColor?: string
+}>`
   position: absolute;
   bottom: 10px;
   right: ${({ hasImage }) => (hasImage ? '40px' : '10px')};
   width: 24px;
   height: 24px;
   border-radius: 20%;
-  background-color: #ff7a45;
+  background-color: ${(props) => props.$bgColor};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -257,6 +265,7 @@ const EventNode = memo(({ data, selected }: EventNodeProps) => {
   const previewStyle = isBlurred ? { filter: 'blur(4px)' } : {}
 
   const { token } = useToken()
+  const { getIconConfig } = useIconConfig()
 
   const mappingEntry = getIconConfig(
     'strelka',
@@ -331,12 +340,12 @@ const EventNode = memo(({ data, selected }: EventNodeProps) => {
       )}
       <LeftWrapper $bgColor={color}>
         {IconComponent ? (
-          <IconComponent style={{ color: '#ffffff', fontSize: '36px' }} />
+          <IconComponent style={{ color: 'white', fontSize: '36px' }} />
         ) : (
           <p>{data.nodeMain[0]}</p>
         )}
       </LeftWrapper>
-      <RightWrapper $acColor={'#999094'}>
+      <RightWrapper $acColor={token.colorTextSecondary}>
         <Tooltip title={data.nodeMain.join(', ')} placement="topLeft">
           <p className="node-header">{data.nodeMain.join(', ')}</p>
         </Tooltip>
@@ -370,11 +379,11 @@ const EventNode = memo(({ data, selected }: EventNodeProps) => {
         type="source"
         position={Position.Right}
         style={{
-          backgroundColor: '#aaa',
+          backgroundColor: token.colorTextTertiary,
           width: 12,
           height: 12,
           borderRadius: '50%',
-          border: '1px solid #bbb',
+          border: `1px solid ${token.colorBorderSecondary}`,
           bottom: '10%',
           transform: 'translate(30%, -50%)',
         }}
@@ -386,23 +395,29 @@ const EventNode = memo(({ data, selected }: EventNodeProps) => {
       </VirustotalWrapper>
       {data.nodeDecryptionSuccess === false && (
         <Tooltip title="Failed to decrypt files. Password not provided or could not be cracked.">
-          <LockIndicatorWrapper>
-            <LockOutlined style={{ color: antdColors.red, fontSize: '16px' }} />
+          <LockIndicatorWrapper
+            $bgColor={token.colorErrorBg}
+            $borderColor={token.colorErrorBorder}
+          >
+            <LockOutlined
+              style={{ color: token.colorError, fontSize: '16px' }}
+            />
           </LockIndicatorWrapper>
         </Tooltip>
       )}
       {data.nodeDecryptionSuccess === true && (
         <Tooltip title="Successfully decrypted files.">
-          <UnlockIndicatorWrapper>
-            <UnlockOutlined
-              style={{ color: antdColors.darkGreen, fontSize: '16px' }}
-            />
+          <UnlockIndicatorWrapper
+            $bgColor={token.green3}
+            $borderColor={token.green7}
+          >
+            <UnlockOutlined style={{ color: token.green7, fontSize: '16px' }} />
           </UnlockIndicatorWrapper>
         </Tooltip>
       )}
       {data.nodeQrData && (
         <Tooltip title="QR Code found">
-          <QrCodePreviewWrapper hasImage={hasImage}>
+          <QrCodePreviewWrapper hasImage={hasImage} $bgColor={token.orange}>
             <QrcodeOutlined style={{ color: 'white' }} />
           </QrCodePreviewWrapper>
         </Tooltip>

--- a/ui/src/components/FileOverviews/EncryptedZipOverview/EncryptedZipOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/EncryptedZipOverview/EncryptedZipOverviewCard.tsx
@@ -1,24 +1,30 @@
-import { Card, Col, Descriptions, Row, Tag, Typography } from 'antd'
-import { antdColors } from '../../../utils/colors'
+import { Card, Col, Descriptions, Row, Tag, Typography, theme } from 'antd'
+import { useMemo } from 'react'
 import type { OverviewCardProps } from '../types'
+const { useToken } = theme
 
 const { Text } = Typography
 
 // Function to determine extraction color based on extracted and total files
-const getExtractionColor = (extracted, total) => {
-  let colorObj = { color: antdColors.red }
+const getExtractionColor = (extracted, total, token) => {
+  let colorObj = { color: token.red }
   if (extracted === total && total > 0) {
-    colorObj = { color: antdColors.darkGreen }
+    colorObj = { color: token.green7 }
   } else if (extracted > 0 && extracted < total) {
-    colorObj = { color: antdColors.deepOrange }
+    colorObj = { color: token.orange }
   }
   return colorObj
 }
 
 const EncryptedZipOverviewCard = ({ data }: OverviewCardProps) => {
+  const token = useToken()
+
   const extracted = data.scan.encrypted_zip.total.extracted
   const total = data.scan.encrypted_zip.total.files
-  const extractionColor = getExtractionColor(extracted, total)
+  const extractionColor = useMemo(
+    () => getExtractionColor(extracted, total, token),
+    [extracted, total, token],
+  )
 
   return (
     <div>

--- a/ui/src/components/FileOverviews/FileIocsOverview/FileIocsOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/FileIocsOverview/FileIocsOverviewCard.tsx
@@ -1,9 +1,9 @@
 import { Space, Tag, Tooltip, Typography } from 'antd'
+import { theme } from 'antd'
 import { useState } from 'react'
-import { antdColors } from '../../../utils/colors'
-import { getIconConfig } from '../../../utils/iconMappingTable'
+import { useIconConfig } from '../../../utils/iconMappingTable'
 import type { FileIocsOverviewProps } from '../types'
-
+const { useToken } = theme
 const { Text } = Typography
 
 /**
@@ -11,6 +11,9 @@ const { Text } = Typography
  * @param {{ data: Object, onFileIocSelect: Function }} props
  */
 const FileIocsOverviewCard = (props: FileIocsOverviewProps) => {
+  const { getIconConfig } = useIconConfig()
+  const { token } = useToken()
+
   const { data, onFileIocSelect } = props
   const [selectedIoc, setSelectedIoc] = useState(null)
   const [showMore, setShowMore] = useState(false) // State to control showing more IOCs
@@ -86,7 +89,7 @@ const FileIocsOverviewCard = (props: FileIocsOverviewProps) => {
     // Get the icon configuration for the current IOC type
     const iconConfig = getIconConfig('strelka', iocType)
     const IconComponent = iconConfig?.icon
-    const iconColor = iconConfig?.color || antdColors.darkPurple // Default to darkPurple if no color is provided
+    const iconColor = iconConfig?.color || token.purple7 // Default to darkPurple if no color is provided
 
     return (
       <Tooltip key={value} title={`Files: ${files.join(', ')}`}>
@@ -98,9 +101,12 @@ const FileIocsOverviewCard = (props: FileIocsOverviewProps) => {
             width: '100%',
             justifyContent: 'space-between',
             alignItems: 'center',
-            background: selectedIoc === value ? `${antdColors.blue}10` : 'none',
+            background:
+              selectedIoc === value ? `${token.colorPrimaryBg}` : 'none',
             border:
-              selectedIoc === value ? `1px solid ${antdColors.blue}` : 'none',
+              selectedIoc === value
+                ? `1px solid ${token.colorPrimaryBorder}`
+                : 'none',
           }}
         >
           <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -161,7 +167,7 @@ const FileIocsOverviewCard = (props: FileIocsOverviewProps) => {
             onClick={() => setShowMore(true)}
             style={{
               cursor: 'pointer',
-              color: '#1890ff',
+              color: token.blue,
               marginLeft: '30px',
               fontSize: '12px',
             }}

--- a/ui/src/components/FileOverviews/FileIocsOverview/FileIocsOverviewLanding.tsx
+++ b/ui/src/components/FileOverviews/FileIocsOverview/FileIocsOverviewLanding.tsx
@@ -1,14 +1,14 @@
-import { Collapse, Tag, Typography } from 'antd'
+import { Collapse, Tag, Typography, theme } from 'antd'
 import { useState } from 'react'
-import { antdColors } from '../../../utils/colors'
 import type { FileIocsOverviewProps } from '../types'
 import FileIocsOverviewCard from './FileIocsOverviewCard'
-
+const { useToken } = theme
 const { Text } = Typography
 
 const FileIocsOverviewLanding = (props: FileIocsOverviewProps) => {
   const { data, onFileIocSelect } = props
   const [filterApplied, setFilterApplied] = useState(false)
+  const { token } = useToken()
 
   const handleIocSelect = (selectedIoc) => {
     setFilterApplied(!!selectedIoc)
@@ -18,7 +18,7 @@ const FileIocsOverviewLanding = (props: FileIocsOverviewProps) => {
   const borderStyle = filterApplied
     ? {
         // Styles when the filter is applied
-        border: `2px solid ${antdColors.blue}50`,
+        border: `2px solid ${token.colorPrimaryBorder}`,
         borderRadius: '8px',
         boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
         padding: '3px',

--- a/ui/src/components/FileOverviews/FileTypeOverview/FileTypeOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/FileTypeOverview/FileTypeOverviewCard.tsx
@@ -1,7 +1,7 @@
-import { Space, Tag, Tooltip, Typography } from 'antd'
+import { Space, Tag, Tooltip, Typography, theme } from 'antd'
 import { useState } from 'react'
-import { antdColors } from '../../../utils/colors'
-import { getIconConfig } from '../../../utils/iconMappingTable'
+const { useToken } = theme
+import { useIconConfig } from '../../../utils/iconMappingTable'
 import type { ScanData } from '../types'
 
 const { Text } = Typography
@@ -18,6 +18,9 @@ interface MimeTypeDetails {
 }
 
 const FileTypeOverviewCard = (props: FileTypeOverviewCardProps) => {
+  const { getIconConfig } = useIconConfig()
+  const { token } = useToken()
+
   const { data, onFileTypeSelect } = props
   const [selectedFileType, setSelectedFileType] = useState(null)
   const [showMoreFileTypes, setShowMoreFileTypes] = useState(false)
@@ -61,7 +64,7 @@ const FileTypeOverviewCard = (props: FileTypeOverviewCardProps) => {
   const renderFileTypeTag = (item) => {
     const iconConfig = getIconConfig('strelka', item.mimeType.toLowerCase())
     const IconComponent = iconConfig?.icon
-    const bgColor = iconConfig?.color || antdColors.darkGray
+    const bgColor = iconConfig?.color
 
     return (
       <Space
@@ -78,13 +81,11 @@ const FileTypeOverviewCard = (props: FileTypeOverviewCardProps) => {
               justifyContent: 'space-between',
               alignItems: 'center',
               background:
-                selectedFileType === item.mimeType
-                  ? `${antdColors.blue}20`
-                  : 'none',
+                selectedFileType === item.mimeType ? `${token.blue}20` : 'none',
               cursor: 'pointer',
               border:
                 selectedFileType === item.mimeType
-                  ? `1px solid ${antdColors.blue}`
+                  ? `1px solid ${token.blue}`
                   : 'none',
             }}
           >
@@ -131,7 +132,7 @@ const FileTypeOverviewCard = (props: FileTypeOverviewCardProps) => {
             style={{
               marginLeft: '30px',
               fontSize: '12px',
-              color: antdColors.blue,
+              color: token.blue,
               cursor: 'pointer',
             }}
           >

--- a/ui/src/components/FileOverviews/FileTypeOverview/FileTypeOverviewLanding.tsx
+++ b/ui/src/components/FileOverviews/FileTypeOverview/FileTypeOverviewLanding.tsx
@@ -1,8 +1,8 @@
-import { Collapse, Tag, Typography } from 'antd'
+import { Collapse, Tag, Typography, theme } from 'antd'
 import { useState } from 'react'
-import { antdColors } from '../../../utils/colors'
 import type { ScanData } from '../types'
 import FileTypeOverviewCard from './FileTypeOverviewCard'
+const { useToken } = theme
 
 const { Text } = Typography
 
@@ -14,6 +14,8 @@ const FileTypeOverviewLanding = (props: FileTypeOverviewLandingProps) => {
   const { data, onFileTypeSelect } = props
   const [filterApplied, setFilterApplied] = useState(false)
 
+  const { token } = useToken()
+
   const handleFileTypeSelect = (selectedFileType) => {
     setFilterApplied(!!selectedFileType)
     onFileTypeSelect(selectedFileType)
@@ -22,7 +24,7 @@ const FileTypeOverviewLanding = (props: FileTypeOverviewLandingProps) => {
   const borderStyle = filterApplied
     ? {
         // Styles when the filter is applied
-        border: `2px solid ${antdColors.blue}50`,
+        border: `2px solid ${token.colorPrimaryBorder}`,
         borderRadius: '8px',
         boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
         padding: '3px',

--- a/ui/src/components/FileOverviews/HeaderOverview/HeaderOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/HeaderOverview/HeaderOverviewCard.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Row, Tag, Tooltip, Typography } from 'antd'
 import { useCallback } from 'react'
-import { getIconConfig } from '../../../utils/iconMappingTable'
+import { useIconConfig } from '../../../utils/iconMappingTable'
 
 import styled from 'styled-components'
 import { APP_CONFIG } from '../../../config'
@@ -133,6 +133,8 @@ interface HeaderOverviewCardProps extends ScanData {
 }
 
 const HeaderOverviewCard = (props: HeaderOverviewCardProps) => {
+  const { getIconConfig } = useIconConfig()
+
   const { data, onOpenVT } = props
   const sortedScannersRun = [...(data?.scanners_run || [])].sort()
   const virustotalData = data.strelka_response[0]?.enrichment?.virustotal

--- a/ui/src/components/FileOverviews/HighlightsOverview/HighlightsOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/HighlightsOverview/HighlightsOverviewCard.tsx
@@ -215,10 +215,7 @@ const HighlightsOverviewCard = (props: HighlightsOverviewCardProps) => {
             )}
             {iocs.length > 0 && (
               <Tooltip title="Potential IOCs">
-                <Tag
-                  color="magenta"
-                  style={{ margin: '1px', fontSize: '10px' }}
-                >
+                <Tag color="purple" style={{ margin: '1px', fontSize: '10px' }}>
                   {iocs.length}
                 </Tag>
               </Tooltip>

--- a/ui/src/components/FileOverviews/HighlightsOverview/HighlightsOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/HighlightsOverview/HighlightsOverviewCard.tsx
@@ -4,11 +4,11 @@ import {
   RightOutlined,
   WarningOutlined,
 } from '@ant-design/icons'
-import { Tag, Tooltip, Typography } from 'antd'
+import { Tag, Tooltip, Typography, theme } from 'antd'
 import { useEffect, useState } from 'react'
-import { antdColors } from '../../../utils/colors'
-import { getIconConfig } from '../../../utils/iconMappingTable'
+import { useIconConfig } from '../../../utils/iconMappingTable'
 import type { ScanData } from '../types'
+const { useToken } = theme
 
 const { Text } = Typography
 
@@ -17,6 +17,7 @@ interface HighlightsOverviewCardProps extends ScanData {
 }
 
 const HighlightsOverviewCard = (props: HighlightsOverviewCardProps) => {
+  const { getIconConfig } = useIconConfig()
   const { data, onFileNameSelect } = props
   const [expandedNodes, setExpandedNodes] = useState(new Set())
   const [selectedNodeId, setSelectedNodeId] = useState(null)
@@ -27,6 +28,8 @@ const HighlightsOverviewCard = (props: HighlightsOverviewCardProps) => {
   const iocsByNode = {}
   const mimeTypeByNode = {}
   const filenameByNode = {}
+
+  const { token } = useToken()
 
   // Function to load more nodes
   const loadMoreNodes = () => {
@@ -132,8 +135,8 @@ const HighlightsOverviewCard = (props: HighlightsOverviewCardProps) => {
     const iocs = iocsByNode[nodeId] || []
     const mimeType = mimeTypeByNode[nodeId]
     const iconConfig = getIconConfig('strelka', mimeType.toLowerCase())
-    const IconComponent = iconConfig?.icon
-    const bgColor = iconConfig?.color || antdColors.darkGray
+    const IconComponent = iconConfig.icon
+    const bgColor = iconConfig.color
 
     const response = data.strelka_response.find(
       (res) => res.file.tree.node === nodeId,
@@ -149,10 +152,12 @@ const HighlightsOverviewCard = (props: HighlightsOverviewCardProps) => {
           overflow: 'hidden',
           cursor: 'pointer',
           background:
-            selectedNodeId === nodeId ? `${antdColors.blue}10` : 'none',
+            selectedNodeId === nodeId ? `${token.colorPrimaryBg}` : 'none',
           borderRadius: '5px',
           border:
-            selectedNodeId === nodeId ? `1px solid ${antdColors.blue}` : 'none',
+            selectedNodeId === nodeId
+              ? `1px solid ${token.colorPrimaryBorder}`
+              : 'none',
         }}
       >
         <div
@@ -210,7 +215,10 @@ const HighlightsOverviewCard = (props: HighlightsOverviewCardProps) => {
             )}
             {iocs.length > 0 && (
               <Tooltip title="Potential IOCs">
-                <Tag color="purple" style={{ margin: '1px', fontSize: '10px' }}>
+                <Tag
+                  color="magenta"
+                  style={{ margin: '1px', fontSize: '10px' }}
+                >
                   {iocs.length}
                 </Tag>
               </Tooltip>
@@ -235,7 +243,8 @@ const HighlightsOverviewCard = (props: HighlightsOverviewCardProps) => {
                 style={{
                   fontSize: '12px',
                   display: 'block',
-                  color: antdColors.purple,
+                  padding: '4px',
+                  color: token.colorTextSecondary,
                 }}
               >
                 <div style={{ display: 'flex' }}>
@@ -244,6 +253,7 @@ const HighlightsOverviewCard = (props: HighlightsOverviewCardProps) => {
                       alignItems: 'start',
                       paddingTop: 2,
                       marginRight: 5,
+                      color: token.colorWarning,
                     }}
                   />
                   {ioc}
@@ -252,9 +262,7 @@ const HighlightsOverviewCard = (props: HighlightsOverviewCardProps) => {
             ))}
             {insights.map((insight) => {
               const isVirusTotal = insight.toLowerCase().includes('virustotal')
-              const textColor = isVirusTotal
-                ? antdColors.red
-                : antdColors.geekblue
+              const textColor = isVirusTotal ? token.volcano : token.geekblue
               return (
                 <Text
                   key={`${nodeId}-insight-${insight}`}
@@ -311,7 +319,11 @@ const HighlightsOverviewCard = (props: HighlightsOverviewCardProps) => {
       ) : (
         <Typography.Title
           level={5}
-          style={{ color: antdColors.gray, textAlign: 'left', margin: '0px' }}
+          style={{
+            color: token.colorTextSecondary,
+            textAlign: 'left',
+            margin: '0px',
+          }}
         >
           No Highlights for this Submission
         </Typography.Title>

--- a/ui/src/components/FileOverviews/RarOverview/RarOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/RarOverview/RarOverviewCard.tsx
@@ -8,10 +8,11 @@ import {
   Table,
   Tag,
   Typography,
+  theme,
 } from 'antd'
 import { useState } from 'react'
-import { antdColors } from '../../../utils/colors'
 import type { OverviewCardProps } from '../types'
+const { useToken } = theme
 
 const { Text } = Typography
 
@@ -26,22 +27,22 @@ const formatBytes = (bytes, decimals = 2) => {
 }
 
 // Function to determine extraction color based on extracted and total files
-const getExtractionColor = (extracted, total) => {
-  if (extracted === total && total > 0) {
-    return { color: antdColors.darkGreen }
+const getExtractionColor = (extracted, total, token) => {
+  if (extracted === total) {
+    return { color: token.green7 }
   }
 
   if (extracted > 0 && extracted < total) {
-    return { color: antdColors.deepOrange }
+    return { color: token.volcano }
   }
 
-  return { color: antdColors.red }
+  return { color: token.colorError }
 }
 
 const RarOverviewCard = (props: OverviewCardProps) => {
   const { data } = props
   const [filter, setFilter] = useState('')
-
+  const { token } = useToken()
   // Check if files exist and filter based on user input
   const files = data.scan.rar.files || []
   const filteredFiles = files
@@ -145,7 +146,7 @@ const RarOverviewCard = (props: OverviewCardProps) => {
 
   const extracted = data.scan.rar.total.extracted
   const total = data.scan.rar.total.files
-  const extractionColor = getExtractionColor(extracted, total)
+  const extractionColor = getExtractionColor(extracted, total, token)
 
   return (
     <div>

--- a/ui/src/components/FileOverviews/SevenZipOverview/SevenZipOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/SevenZipOverview/SevenZipOverviewCard.tsx
@@ -8,9 +8,11 @@ import {
   Table,
   Tag,
   Typography,
+  theme,
 } from 'antd'
 import { useState } from 'react'
-import { antdColors } from '../../../utils/colors'
+
+const { useToken } = theme
 
 const { Text } = Typography
 
@@ -23,22 +25,22 @@ const formatBytes = (bytes, decimals = 2) => {
   const i = Math.floor(Math.log(bytes) / Math.log(k))
   return `${Number.parseFloat((bytes / k ** i).toFixed(dm))} ${sizes[i]}`
 }
-
 // Function to determine extraction color based on extracted and total files
-const getExtractionColor = (extracted, total) => {
-  if (extracted === total && total > 0) {
-    return { color: antdColors.darkGreen }
+const getExtractionColor = (extracted, total, token) => {
+  if (extracted === total) {
+    return { color: token.green7 }
   }
 
   if (extracted > 0 && extracted < total) {
-    return { color: antdColors.deepOrange }
+    return { color: token.volcano }
   }
 
-  return { color: antdColors.red }
+  return { color: token.colorError }
 }
 
 const SevenZipOverviewCard = ({ data }) => {
   const [filter, setFilter] = useState('')
+  const { token } = useToken()
 
   // Check if files exist and filter based on user input
   const files = data.scan.seven_zip.files || []
@@ -85,7 +87,7 @@ const SevenZipOverviewCard = ({ data }) => {
 
   const extracted = data.scan.seven_zip.total.extracted
   const total = data.scan.seven_zip.total.files
-  const extractionColor = getExtractionColor(extracted, total)
+  const extractionColor = getExtractionColor(extracted, total, token)
 
   return (
     <div>

--- a/ui/src/components/FileOverviews/TlshOverview/TlshOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/TlshOverview/TlshOverviewCard.tsx
@@ -1,9 +1,8 @@
-import { Tag, Typography } from 'antd'
-import { antdColors } from '../../../utils/colors'
+import { Tag, Typography, theme } from 'antd'
 import '../../../styles/TlshOverviewCard.css'
 import type { CSSProperties } from 'react'
 import type { OverviewCardProps } from '../types'
-
+const { useToken } = theme
 const { Text } = Typography
 
 interface TlshCustomCss extends CSSProperties {
@@ -16,6 +15,8 @@ const TlshOverviewCard = (props: OverviewCardProps) => {
   const score = match.score
   const family = match.family
   const matchedTlsh = match.tlsh
+
+  const { token } = useToken()
 
   // Define the indexes where we want to show the scores
   const scorePositions = {
@@ -44,7 +45,7 @@ const TlshOverviewCard = (props: OverviewCardProps) => {
       'Quite Different': 'gold',
       'Very Different': 'lime',
     }
-    return colorMapping[description] || antdColors.gray
+    return colorMapping[description] || token.colorTextSecondary
   }
 
   // Construct the sentence with the provided values
@@ -87,12 +88,12 @@ const TlshOverviewCard = (props: OverviewCardProps) => {
 
   // antd color gradient
   const colorGradient = [
-    antdColors.red, // Very Similar
-    antdColors.volcano,
-    antdColors.orange,
-    antdColors.gold,
-    antdColors.lime,
-    antdColors.green, // Very Different
+    token.red7, // Very Similar
+    token.volcano7,
+    token.orange,
+    token.gold,
+    token.lime7,
+    token.green7, // Very Different
   ]
 
   // Assume 300 is the highest score for TLSH comparison (It's not, but let's pretend)
@@ -111,14 +112,14 @@ const TlshOverviewCard = (props: OverviewCardProps) => {
   // Update the color gradient logic to handle scores of 300 or higher
   const getColorForIndex = (index) => {
     if (index === numberOfParts - 1 && score >= maxScore) {
-      return antdColors.green
+      return token.green
     }
 
     return index <= scoreIndex
       ? colorGradient[
           Math.floor((colorGradient.length - 1) * (index / (numberOfParts - 1)))
         ]
-      : antdColors.lightGray
+      : token.colorTextDisabled
   }
 
   return (

--- a/ui/src/components/FileOverviews/YaraOverview/YaraOverviewLanding.tsx
+++ b/ui/src/components/FileOverviews/YaraOverview/YaraOverviewLanding.tsx
@@ -1,8 +1,10 @@
 import { Collapse, Tag, Typography } from 'antd'
+import { theme } from 'antd'
 import { useState } from 'react'
-import { antdColors } from '../../../utils/colors'
 import type { ScanData } from '../types'
 import YaraTypeOverviewCard from './YaraTypeOverviewCard'
+
+const { useToken } = theme
 
 const { Text } = Typography
 
@@ -11,9 +13,9 @@ interface YaraOverviewLandingProps extends ScanData {
 }
 
 const YaraOverviewLanding = (props: YaraOverviewLandingProps) => {
+  const { token } = useToken()
   const { data, onFileYaraSelect } = props
   const [filterApplied, setFilterApplied] = useState(false)
-
   const handleYaraSelect = (selectedYara) => {
     setFilterApplied(!!selectedYara)
     onFileYaraSelect(selectedYara)
@@ -22,7 +24,7 @@ const YaraOverviewLanding = (props: YaraOverviewLandingProps) => {
   const borderStyle = filterApplied
     ? {
         // Styles when the filter is applied
-        border: `2px solid ${antdColors.purple}50`,
+        border: `2px solid ${token.purple5}`,
         borderRadius: '8px',
         boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
         padding: '3px',
@@ -55,7 +57,10 @@ const YaraOverviewLanding = (props: YaraOverviewLandingProps) => {
               <Text>File YARA Matches</Text>
               {filterApplied && (
                 <Tag
-                  style={{ color: `${antdColors.purple}99`, fontWeight: 700 }}
+                  style={{
+                    fontWeight: 700,
+                  }}
+                  color="purple"
                 >
                   Filter Applied
                 </Tag>

--- a/ui/src/components/FileOverviews/YaraOverview/YaraTypeOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/YaraOverview/YaraTypeOverviewCard.tsx
@@ -1,10 +1,10 @@
 import { BookOutlined, WarningOutlined } from '@ant-design/icons'
-import { Row, Tag, Tooltip, Typography } from 'antd'
+import { Row, Tag, Tooltip, Typography, theme } from 'antd'
 import { useState } from 'react'
-import { antdColors } from '../../../utils/colors'
 import type { ScanData } from '../types'
 
 const { Text } = Typography
+const { useToken } = theme
 
 interface YaraTypeOverviewCardProps extends ScanData {
   onFileYaraSelect: (selectedYara: string | null) => void
@@ -15,6 +15,7 @@ interface YaraTypeOverviewCardProps extends ScanData {
  */
 const YaraTypeOverviewCard = (props: YaraTypeOverviewCardProps) => {
   const { data, onFileYaraSelect } = props
+  const { token } = useToken()
   const [selectedYara, setSelectedYara] = useState(null)
   const [showMoreSuspicious, setShowMoreSuspicious] = useState(false)
   const [showMoreClassifiers, setShowMoreClassifiers] = useState(false)
@@ -99,14 +100,16 @@ const YaraTypeOverviewCard = (props: YaraTypeOverviewCardProps) => {
             background:
               selectedYara === item.yara
                 ? isSuspicious
-                  ? `${antdColors.deepOrange}20`
-                  : `${antdColors.blue}20`
+                  ? token.colorErrorBg
+                  : token.colorPrimaryBg
                 : 'none',
             cursor: 'pointer',
+            paddingTop: '3px',
+            paddingBottom: '3px',
             border:
               selectedYara === item.yara
                 ? `1px solid ${
-                    isSuspicious ? antdColors.deepOrange : antdColors.blue
+                    isSuspicious ? token.volcano6 : token.colorPrimaryBorder
                   }`
                 : 'none',
           }}
@@ -116,8 +119,8 @@ const YaraTypeOverviewCard = (props: YaraTypeOverviewCardProps) => {
               className="file-type-box"
               style={{
                 backgroundColor: isSuspicious
-                  ? antdColors.deepOrange
-                  : antdColors.darkGray,
+                  ? token.volcano6
+                  : token.colorTextSecondary,
                 marginRight: '8px',
               }}
             >
@@ -171,7 +174,7 @@ const YaraTypeOverviewCard = (props: YaraTypeOverviewCardProps) => {
               style={{
                 marginLeft: '30px',
                 fontSize: '12px',
-                color: antdColors.blue,
+                color: token.colorPrimary,
                 cursor: 'pointer',
               }}
             >

--- a/ui/src/components/FileOverviews/ZipOverview/ZipOverviewCard.tsx
+++ b/ui/src/components/FileOverviews/ZipOverview/ZipOverviewCard.tsx
@@ -8,12 +8,13 @@ import {
   Table,
   Tag,
   Typography,
+  theme,
 } from 'antd'
 import { useState } from 'react'
-import { antdColors } from '../../../utils/colors'
 import type { OverviewCardProps } from '../types'
 
 const { Text } = Typography
+const { useToken } = theme
 
 // Utility function to format bytes into more readable formats
 const formatBytes = (bytes, decimals = 2) => {
@@ -26,29 +27,30 @@ const formatBytes = (bytes, decimals = 2) => {
 }
 
 // Function to determine style based on compression rate
-const getCompressionRateStyle = (rate) => {
+const getCompressionRateStyle = (rate, token) => {
   if (rate > 90) {
-    return { color: antdColors.red, fontWeight: 'bold' }
+    return { color: token.colorError, fontWeight: 'bold' }
   }
 
-  return { color: antdColors.darkGreen, fontWeight: 'bold' }
+  return { color: token.green7, fontWeight: 'bold' }
 }
 
 // Function to determine extraction color based on extracted and total files
-const getExtractionColor = (extracted, total) => {
+const getExtractionColor = (extracted, total, token) => {
   if (extracted === total) {
-    return { color: antdColors.darkGreen }
+    return { color: token.green7 }
   }
 
   if (extracted > 0 && extracted < total) {
-    return { color: antdColors.deepOrange }
+    return { color: token.volcano }
   }
 
-  return { color: antdColors.red }
+  return { color: token.colorError }
 }
 
 const ZipOverviewCard = (props: OverviewCardProps) => {
   const { data } = props
+  const { token } = useToken()
   const [filter, setFilter] = useState('')
 
   // Filter files based on user input
@@ -101,7 +103,7 @@ const ZipOverviewCard = (props: OverviewCardProps) => {
           style={{
             float: 'right',
             fontSize: '12px',
-            ...getCompressionRateStyle(rate),
+            ...getCompressionRateStyle(rate, token),
           }}
         >
           {rate.toFixed(2)}%
@@ -158,7 +160,7 @@ const ZipOverviewCard = (props: OverviewCardProps) => {
 
   const extracted = data.scan.zip.total.extracted
   const total = data.scan.zip.total.files
-  const extractionColor = getExtractionColor(extracted, total)
+  const extractionColor = getExtractionColor(extracted, total, token)
 
   return (
     <div>
@@ -208,7 +210,10 @@ const ZipOverviewCard = (props: OverviewCardProps) => {
               <Text
                 style={{
                   fontSize: '12px',
-                  ...getCompressionRateStyle(data.scan.zip.compression_rate),
+                  ...getCompressionRateStyle(
+                    data.scan.zip.compression_rate,
+                    token,
+                  ),
                 }}
               >
                 {data.scan.zip.compression_rate}%

--- a/ui/src/components/SubmissionTable.tsx
+++ b/ui/src/components/SubmissionTable.tsx
@@ -22,7 +22,7 @@ import { Link } from 'react-router'
 
 import { useVirusTotalApiKey } from '../hooks/useVirusTotalApiKey'
 import { useMessageApi } from '../providers/MessageProvider'
-import { getIconConfig } from '../utils/iconMappingTable'
+import { useIconConfig } from '../utils/iconMappingTable'
 import VirusTotalAugmentDrawer from './VirusTotal/VirusTotalAugmentDrawer'
 
 import { debounce } from 'lodash'
@@ -50,6 +50,7 @@ const SubmissionTable = () => {
   const [resubmittingIds, setResubmittingIds] = useState<Set<string>>(new Set())
   const { isApiKeyAvailable } = useVirusTotalApiKey()
   const message = useMessageApi()
+  const { getIconConfig } = useIconConfig()
 
   // Function to handle opening the VT Augment
   const handleVtOpen = (sha256Hash) => {
@@ -409,7 +410,7 @@ const SubmissionTable = () => {
         // }
         // Lookup Icon and Color entry based on mimeType
         const mappingEntry = getIconConfig('strelka', mimeType.toLowerCase())
-        const bgColor = mappingEntry?.color || 'defaultBackgroundColor'
+        const tagColor = mappingEntry?.name || 'default'
 
         const tagStyle = {
           fontSize: '10px',
@@ -434,7 +435,7 @@ const SubmissionTable = () => {
               justifyContent: 'center',
             }}
           >
-            <Tag style={tagStyle} color={bgColor}>
+            <Tag style={tagStyle} color={tagColor}>
               {mimeType}
             </Tag>
           </div>

--- a/ui/src/components/Visualizations/MimeTypeBarChart.tsx
+++ b/ui/src/components/Visualizations/MimeTypeBarChart.tsx
@@ -11,7 +11,7 @@ import {
   YAxis,
 } from 'recharts'
 import { useMimeTypeStats } from '../../hooks/useMimeTypeStats'
-import { getIconConfig } from '../../utils/iconMappingTable'
+import { useIconConfig } from '../../utils/iconMappingTable'
 
 interface MimeTypeBarChartProps {
   height: number
@@ -22,6 +22,7 @@ interface MimeTypeBarChartProps {
  * @param {number} height - Height of the chart container.
  */
 const MimeTypeBarChart = ({ height }: MimeTypeBarChartProps) => {
+  const { getIconConfig } = useIconConfig()
   const { data, isLoading } = useMimeTypeStats()
 
   if (isLoading) {

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import {
   MessageOutlined,
 } from '@ant-design/icons'
 import { useQueryClient } from '@tanstack/react-query'
-import { Card, Col, Input, Row, Statistic, Typography } from 'antd'
+import { Card, Col, Input, Row, Statistic, Typography, theme } from 'antd'
 import Dropzone from '../components/Dropzone'
 import PageWrapper from '../components/PageWrapper'
 import SubmissionTable from '../components/SubmissionTable'
@@ -20,6 +20,7 @@ import { useMessageApi } from '../providers/MessageProvider'
 const { Title, Text } = Typography
 
 const DashboardPage = () => {
+  const { token } = theme.useToken()
   const message = useMessageApi()
 
   const [fileDescription, setFileDescription] = useState(
@@ -76,22 +77,22 @@ const DashboardPage = () => {
     {
       title: 'All Time Submissions',
       value: stats?.all_time,
-      valueStyle: { color: '#3f8600' },
+      valueStyle: { color: token.green7 },
     },
     {
       title: 'Last 30 Days',
       value: stats?.thirty_days,
-      valueStyle: { color: '#cf1322' },
+      valueStyle: { color: token.red7 },
     },
     {
       title: 'Last 7 Days',
       value: stats?.seven_days,
-      valueStyle: { color: '#125ecf' },
+      valueStyle: { color: token.blue7 },
     },
     {
       title: 'Last 24 Hours',
       value: stats?.twentyfour_hours,
-      valueStyle: { color: '#cf8512' },
+      valueStyle: { color: token.gold7 },
     },
   ]
 
@@ -122,7 +123,7 @@ const DashboardPage = () => {
                   left: 0,
                   right: 0,
                   bottom: 0,
-                  backgroundColor: 'rgba(255, 255, 255, 0.8)',
+                  backgroundColor: `${token.colorBgMask}`,
                   zIndex: 10,
                   display: 'flex',
                   flexDirection: 'column',
@@ -130,7 +131,7 @@ const DashboardPage = () => {
                   justifyContent: 'center',
                   borderRadius: '4px',
                   textAlign: 'center',
-                  color: 'grey',
+                  color: token.colorTextSecondary,
                   fontSize: '18px',
                   padding: '20px',
                 }}

--- a/ui/src/pages/SubmissionView.tsx
+++ b/ui/src/pages/SubmissionView.tsx
@@ -16,7 +16,7 @@ import FileTreeCardWithProvider from '../components/FileFlow/FileTreeCardWithPro
 
 import VirusTotalAugmentDrawer from '../components/VirusTotal/VirusTotalAugmentDrawer'
 
-import { getIconConfig } from '../utils/iconMappingTable'
+import { useIconConfig } from '../utils/iconMappingTable'
 
 import '../styles/IconContainer.css'
 
@@ -38,6 +38,8 @@ const SubmissionsPage = () => {
   const { data, isLoading } = useFetchScanById(id)
   const message = useMessageApi()
   const navigate = useNavigate()
+  const { getIconConfig } = useIconConfig()
+
   // TODO: handle 404
 
   const [selectedNodeData, setSelectedNodeData] =

--- a/ui/src/styles/TlshOverviewCard.css
+++ b/ui/src/styles/TlshOverviewCard.css
@@ -75,6 +75,7 @@
   font-size: 11px;
   font-weight: 800;
   word-break: keep-all;
+  color: #fff;
 }
 
 .tick-text {

--- a/ui/src/tests/colors.test.ts
+++ b/ui/src/tests/colors.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from 'vitest'
-import { antdColors, getColorForString } from '../utils/colors'
+import { getColorForString } from '../utils/colors'
+import { PresetColors } from 'antd/lib/theme/interface/presetColors'
 
 test('should return a color for a given string', () => {
   const input = 'test'
   const color = getColorForString(input)
-  expect(Object.values(antdColors)).toContain(color)
+  expect(Object.values(PresetColors)).toContain(color)
 })
 
 test('should return the same color for the same input string', () => {
@@ -17,13 +18,13 @@ test('should return the same color for the same input string', () => {
 test('should return a color for an empty string', () => {
   const input = ''
   const color = getColorForString(input)
-  expect(color).toBe(antdColors.darkGray)
+  expect(color).toBe('default')
 })
 
 test('should return a color for an array of strings', () => {
   const input = ['array', 'of', 'strings']
   const color = getColorForString(input)
-  expect(Object.values(antdColors)).toContain(color)
+  expect(Object.values(PresetColors)).toContain(color)
 })
 
 test('should return the same color for the same array of strings', () => {
@@ -36,17 +37,17 @@ test('should return the same color for the same array of strings', () => {
 test('should return a color for a single-character string', () => {
   const input = 'a'
   const color = getColorForString(input)
-  expect(Object.values(antdColors)).toContain(color)
+  expect(Object.values(PresetColors)).toContain(color)
 })
 
 test('should handle special characters in the input string', () => {
   const input = '!@#$%^&*()'
   const color = getColorForString(input)
-  expect(Object.values(antdColors)).toContain(color)
+  expect(Object.values(PresetColors)).toContain(color)
 })
 
 test('should handle very long strings', () => {
   const input = 'a'.repeat(1000)
   const color = getColorForString(input)
-  expect(Object.values(antdColors)).toContain(color)
+  expect(Object.values(PresetColors)).toContain(color)
 })

--- a/ui/src/utils/colors.ts
+++ b/ui/src/utils/colors.ts
@@ -1,43 +1,5 @@
 import { PresetColors } from 'antd/lib/theme/interface/presetColors'
 
-export const antdColors = {
-  blue: '#1890ff',
-  purple: '#722ed1',
-  magenta: '#eb2f96',
-  red: '#ff4d4f',
-  volcano: '#fa541c',
-  orange: '#fa8c16',
-  gold: '#faad14',
-  yellow: '#fadb14',
-  lime: '#a0d911',
-  green: '#52c41a',
-  cyan: '#13c2c2',
-  geekblue: '#2f54eb',
-  gray: '#8c8c8c',
-  darkGray: '#595959',
-  pink: '#eb2f96',
-  brown: '#8D6E63',
-  teal: '#009688',
-  indigo: '#3F51B5',
-  deepPurple: '#673AB7',
-  deepOrange: '#FF5722',
-  limeGreen: '#CDDC39',
-  amber: '#FFC107',
-  lightBlue: '#5dafff',
-  lightRed: '#ffccc7',
-  tealGreen: '#00b2b2',
-  lightGreen: '#b7eb8f',
-  lightGray: '#d9d9d9',
-  darkPurple: '#330099',
-  darkGreen: '#389e0d',
-  olive: '#808000',
-  darkRed: '#8b0000',
-  darkBlue: '#00008b',
-  violet: '#8A2BE2',
-}
-
-export const antdColorNames = PresetColors
-
 /**
  * Get an Ant Design color name for a given string in a deterministic way.
  * @param input
@@ -49,13 +11,13 @@ export const getColorForString = (input: string | string[]): string => {
     return getColorForString(input.join(''))
   }
   if (!input) {
-    return antdColors.darkGray
+    return 'default'
   }
   let hash = 0
   for (let i = 0; i < input.length; i++) {
     hash = input.charCodeAt(i) + ((hash << 5) - hash)
   }
-  const colorKeys = Object.keys(antdColors)
-  const index = Math.abs(hash) % colorKeys.length
-  return antdColors[colorKeys[index]]
+
+  const index = Math.abs(hash) % PresetColors.length
+  return PresetColors[index]
 }

--- a/ui/src/utils/iconMappingTable.ts
+++ b/ui/src/utils/iconMappingTable.ts
@@ -25,593 +25,770 @@ import {
   TableOutlined,
 } from '@ant-design/icons'
 
-import { antdColors } from './colors'
+import * as colors from '@ant-design/colors'
+import { useCallback, useMemo } from 'react'
 
-export const flowIconMappingTable = {
-  strelka: {
-    // -----------
-    // YARA Types
-    // -----------
-    archive: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    audio: {
-      icon: PlaySquareOutlined,
-      color: antdColors.green,
-    },
-    capture: {
-      icon: DatabaseOutlined,
-      color: antdColors.geekblue,
-    },
-    certificate: {
-      icon: LockOutlined,
-      color: antdColors.cyan,
-    },
-    compressed: {
-      icon: FileZipOutlined,
-      color: antdColors.orange,
-    },
-    document: {
-      icon: FileTextOutlined,
-      color: antdColors.blue,
-    },
-    email: {
-      icon: MailOutlined,
-      color: antdColors.indigo,
-    },
-    encoded: {
-      icon: CodeOutlined,
-      color: antdColors.deepOrange,
-    },
-    executable: {
-      icon: PlaySquareOutlined,
-      color: antdColors.red,
-    },
-    image: {
-      icon: PictureOutlined,
-      color: antdColors.amber,
-    },
-    metadata: {
-      icon: TableOutlined,
-      color: antdColors.lime,
-    },
-    multimedia: {
-      icon: PlaySquareOutlined,
-      color: antdColors.purple,
-    },
-    package: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    script: {
-      icon: CodeOutlined,
-      color: antdColors.teal,
-    },
-    text: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    video: {
-      icon: PlaySquareOutlined,
-      color: antdColors.magenta,
-    },
-    PII: {
-      icon: LockOutlined,
-      color: antdColors.cyan,
-    },
-    '7zip_file': {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    arj_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    cab_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    cpio_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    dmg_disk_image: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    dmg_encrypted_disk_image: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    encrypted_zip: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    encrypted_word_document: {
-      icon: FileWordOutlined,
-      color: antdColors.geekblue,
-    },
-    hfsplus_disk_image: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    iso_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    mhtml_file: {
-      icon: FileTextOutlined,
-      color: antdColors.blue,
-    },
-    rar_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    tar_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    udf_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    vhd_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    vhdx_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    xar_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    zip_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    mp3_file: {
-      icon: PlaySquareOutlined,
-      color: antdColors.green,
-    },
-    pcap_file: {
-      icon: DatabaseOutlined,
-      color: antdColors.geekblue,
-    },
-    pcapng_file: {
-      icon: DatabaseOutlined,
-      color: antdColors.geekblue,
-    },
-    pkcs7_file: {
-      icon: LockOutlined,
-      color: antdColors.cyan,
-    },
-    x509_der_file: {
-      icon: LockOutlined,
-      color: antdColors.cyan,
-    },
-    x509_pem_file: {
-      icon: LockOutlined,
-      color: antdColors.cyan,
-    },
-    bzip2_file: {
-      icon: FileZipOutlined,
-      color: antdColors.orange,
-    },
-    gzip_file: {
-      icon: FileZipOutlined,
-      color: antdColors.orange,
-    },
-    lzma_file: {
-      icon: FileZipOutlined,
-      color: antdColors.orange,
-    },
-    xz_file: {
-      icon: FileZipOutlined,
-      color: antdColors.orange,
-    },
-    zlib_file: {
-      icon: FileZipOutlined,
-      color: antdColors.orange,
-    },
-    doc_subheader_file: {
-      icon: FileWordOutlined,
-      color: antdColors.geekblue,
-    },
-    excel4_file: {
-      icon: FileExcelOutlined,
-      color: antdColors.green,
-    },
-    iqy_file: {
-      icon: FileExcelOutlined,
-      color: antdColors.green,
-    },
-    onenote_file: {
-      icon: FileWordOutlined,
-      color: antdColors.purple,
-    },
-    mso_file: {
-      icon: FileTextOutlined,
-      color: antdColors.blue,
-    },
-    olecf_file: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    ooxml_file: {
-      icon: FileTextOutlined,
-      color: antdColors.blue,
-    },
-    pdf_file: {
-      icon: FilePdfOutlined,
-      color: antdColors.red,
-    },
-    poi_hpbf_file: {
-      icon: FileTextOutlined,
-      color: antdColors.blue,
-    },
-    rtf_file: {
-      icon: FileTextOutlined,
-      color: antdColors.blue,
-    },
-    vbframe_file: {
-      icon: CodeOutlined,
-      color: antdColors.deepOrange,
-    },
-    wordml_file: {
-      icon: FileWordOutlined,
-      color: antdColors.geekblue,
-    },
-    xfdf_file: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    email_file: {
-      icon: MailOutlined,
-      color: antdColors.indigo,
-    },
-    tnef_file: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    base64_pe: {
-      icon: CodeOutlined,
-      color: antdColors.deepOrange,
-    },
-    pgp_file: {
-      icon: LockOutlined,
-      color: antdColors.cyan,
-    },
-    elf_file: {
-      icon: PlaySquareOutlined,
-      color: antdColors.red,
-    },
-    lnk_file: {
-      icon: FileOutlined,
-      color: antdColors.darkGray,
-    },
-    macho_file: {
-      icon: PlaySquareOutlined,
-      color: antdColors.red,
-    },
-    mz_file: {
-      icon: PlaySquareOutlined,
-      color: antdColors.red,
-    },
-    bmp_file: {
-      icon: PictureOutlined,
-      color: antdColors.blue,
-    },
-    cmap_file: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    gif_file: {
-      icon: FileGifOutlined,
-      color: antdColors.blue,
-    },
-    jpeg_file: {
-      icon: PictureOutlined,
-      color: antdColors.blue,
-    },
-    postscript_file: {
-      icon: FileTextOutlined,
-      color: antdColors.blue,
-    },
-    png_file: {
-      icon: PictureOutlined,
-      color: antdColors.blue,
-    },
-    psd_file: {
-      icon: FileImageOutlined,
-      color: antdColors.green,
-    },
-    psd_image_file: {
-      icon: FileImageOutlined,
-      color: antdColors.green,
-    },
-    svg_file: {
-      icon: FileImageOutlined,
-      color: antdColors.green,
-    },
-    xicc_file: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    xmp_file: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    jar_manifest_file: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    bplist_file: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    fws_file: {
-      icon: PlaySquareOutlined,
-      color: antdColors.purple,
-    },
-    cws_file: {
-      icon: PlaySquareOutlined,
-      color: antdColors.purple,
-    },
-    zws_file: {
-      icon: PlaySquareOutlined,
-      color: antdColors.purple,
-    },
-    debian_package_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    rpm_file: {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    hacktool_win_shellcode_donut: {
-      icon: CodeOutlined,
-      color: antdColors.deepOrange,
-    },
-    upx_file: {
-      icon: FileZipOutlined,
-      color: antdColors.orange,
-    },
-    batch_file: {
-      icon: CodeOutlined,
-      color: antdColors.deepOrange,
-    },
-    javascript_file: {
-      icon: CodeOutlined,
-      color: antdColors.deepOrange,
-    },
-    vb_file: {
-      icon: CodeOutlined,
-      color: antdColors.deepOrange,
-    },
-    hta_file: {
-      icon: CodeOutlined,
-      color: antdColors.red,
-    },
-    html_file: {
-      icon: Html5Outlined,
-      color: antdColors.purple,
-    },
-    ini_file: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    json_file: {
-      icon: FileOutlined,
-      color: antdColors.indigo,
-    },
-    php_file: {
-      icon: CodeOutlined,
-      color: antdColors.deepOrange,
-    },
-    plist_file: {
-      icon: FileTextOutlined,
-      color: antdColors.darkGray,
-    },
-    soap_file: {
-      icon: FileTextOutlined,
-      color: antdColors.blue,
-    },
-    xml_file: {
-      icon: FileTextOutlined,
-      color: antdColors.blue,
-    },
-    avi_file: {
-      icon: PlaySquareOutlined,
-      color: antdColors.red,
-    },
-    wmv_file: {
-      icon: PlaySquareOutlined,
-      color: antdColors.red,
-    },
-    credit_cards: {
-      icon: LockOutlined,
-      color: antdColors.cyan,
-    },
-    vsto_file: {
-      icon: FileTextOutlined,
-      color: antdColors.blue,
-    },
-    // -----------
-    // Mime Types (Overridden by YARA Type, if exists)
-    // -----------
-    'application/octet-stream': {
-      icon: NumberOutlined,
-      color: antdColors.brown,
-    },
-    'text/plain': {
-      icon: FileTextOutlined,
-      color: antdColors.gray,
-    },
-    'text/html': {
-      icon: Html5Outlined,
-      color: antdColors.purple,
-    },
-    'text/csv': {
-      icon: TableOutlined,
-      color: antdColors.lime,
-    },
-    'image/png': {
-      icon: PictureOutlined,
-      color: antdColors.blue,
-    },
-    'image/jpeg': {
-      icon: PictureOutlined,
-      color: antdColors.blue,
-    },
-    'application/pdf': {
-      icon: FilePdfOutlined,
-      color: antdColors.red,
-    },
-    'text/xml': {
-      icon: FileTextOutlined,
-      color: antdColors.orange,
-    },
-    'application/x-executable': {
-      icon: PlaySquareOutlined,
-      color: antdColors.red,
-    },
-    'application/zip': {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    'application/vnd.ms-excel': {
-      icon: FileExcelOutlined,
-      color: antdColors.green,
-    },
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': {
-      icon: FileExcelOutlined,
-      color: antdColors.green,
-    },
-    'application/msword': {
-      icon: FileWordOutlined,
-      color: antdColors.geekblue,
-    },
-    'application/x-dosexec': {
-      icon: PlaySquareOutlined,
-      color: antdColors.red,
-    },
-    'application/x-dbt': {
-      icon: DatabaseOutlined,
-      color: antdColors.purple,
-    },
-    'application/encrypted': {
-      icon: LockOutlined,
-      color: antdColors.cyan,
-    },
-    'application/x-matlab-data': {
-      icon: CalculatorOutlined,
-      color: antdColors.yellow,
-    },
-    'application/x-pnf': {
-      icon: FileOutlined,
-      color: antdColors.gold,
-    },
-    'application/x-empty': {
-      icon: FileUnknownOutlined,
-      color: antdColors.gray,
-    },
-    'application/cdfv2': {
-      icon: FileTextOutlined,
-      color: antdColors.gray,
-    },
-    'application/gzip': {
-      icon: FileZipOutlined,
-      color: antdColors.gold,
-    },
-    'image/svg+xml': {
-      icon: FileImageOutlined,
-      color: antdColors.green,
-    },
-    'message/rfc822': {
-      icon: MailOutlined,
-      color: antdColors.blue,
-    },
-    'text/rtf': {
-      icon: FileWordOutlined,
-      color: antdColors.green,
-    },
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': {
-      icon: FileWordOutlined,
-      color: antdColors.green,
-    },
-    'application/x-wine-extension-ini': {
-      icon: ExperimentOutlined,
-      color: antdColors.magenta,
-    },
-    'application/x-setupscript': {
-      icon: CodeOutlined,
-      color: antdColors.cyan,
-    },
-    'text/css': {
-      icon: CodeOutlined,
-      color: antdColors.teal,
-    },
-    'application/json': {
-      icon: FileOutlined,
-      color: antdColors.indigo,
-    },
-    'application/xml': {
-      icon: FileOutlined,
-      color: antdColors.deepPurple,
-    },
-    'application/javascript': {
-      icon: CodeOutlined,
-      color: antdColors.deepOrange,
-    },
-    'text/markdown': {
-      icon: FileMarkdownOutlined,
-      color: antdColors.limeGreen,
-    },
-    'image/gif': {
-      icon: FileGifOutlined,
-      color: antdColors.amber,
-    },
-    domain: {
-      icon: GlobalOutlined,
-      color: antdColors.blue,
-    },
-    url: {
-      icon: LinkOutlined,
-      color: antdColors.geekblue,
-    },
-    md5: {
-      icon: SafetyCertificateOutlined,
-      color: antdColors.violet,
-    },
-    sha1: {
-      icon: SafetyCertificateOutlined,
-      color: antdColors.purple,
-    },
-    sha256: {
-      icon: SafetyCertificateOutlined,
-      color: antdColors.indigo,
-    },
-    ip: {
-      icon: NumberOutlined,
-      color: antdColors.orange,
-    },
-  },
-}
+import { theme } from 'antd'
+const { useToken } = theme
 
-// Default icon and color
-const defaultIconConfig = {
-  icon: FileTextOutlined,
-  color: antdColors.darkGray,
-}
+//import { antdColors } from './colors'
 
-// Function to get icon configuration
-export const getIconConfig = (category, type) => {
-  if (flowIconMappingTable[category]?.[type]) {
-    return flowIconMappingTable[category][type]
+// // Default icon and color
+// const defaultIconConfig = {
+//   icon: FileTextOutlined,
+//   color: darkGray,
+// }
+
+// // Function to get icon configuration
+// export const getIconConfig = (category, type) => {
+//   if (flowIconMappingTable[category]?.[type]) {
+//     return flowIconMappingTable[category][type]
+//   }
+//   return defaultIconConfig
+// }
+
+const GRAY = colors.gray[7]
+const DARK_GRAY = colors.gray[5]
+
+export const useIconConfig = () => {
+  const { token } = useToken()
+
+  const flowIconMappingTable = useMemo(
+    () => ({
+      defaultIcon: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      // -----------
+      // YARA Types
+      // -----------
+      archive: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      audio: {
+        icon: PlaySquareOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      capture: {
+        icon: DatabaseOutlined,
+        color: token.geekblue,
+        name: 'geekblue',
+      },
+      certificate: {
+        icon: LockOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      compressed: {
+        icon: FileZipOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      document: {
+        icon: FileTextOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      email: {
+        icon: MailOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      encoded: {
+        icon: CodeOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      executable: {
+        icon: PlaySquareOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      image: {
+        icon: PictureOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      metadata: {
+        icon: TableOutlined,
+        color: token.lime,
+        name: 'lime',
+      },
+      multimedia: {
+        icon: PlaySquareOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      package: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      script: {
+        icon: CodeOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      text: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      video: {
+        icon: PlaySquareOutlined,
+        color: token.magenta,
+        name: 'magenta',
+      },
+      PII: {
+        icon: LockOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      '7zip_file': {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      arj_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      cab_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      cpio_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      dmg_disk_image: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      dmg_encrypted_disk_image: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      encrypted_zip: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      encrypted_word_document: {
+        icon: FileWordOutlined,
+        color: token.geekblue,
+        name: 'geekblue',
+      },
+      hfsplus_disk_image: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      iso_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      mhtml_file: {
+        icon: FileTextOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      rar_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      tar_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      udf_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      vhd_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      vhdx_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      xar_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      zip_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      mp3_file: {
+        icon: PlaySquareOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      pcap_file: {
+        icon: DatabaseOutlined,
+        color: token.geekblue,
+        name: 'geekblue',
+      },
+      pcapng_file: {
+        icon: DatabaseOutlined,
+        color: token.geekblue,
+        name: 'geekblue',
+      },
+      pkcs7_file: {
+        icon: LockOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      x509_der_file: {
+        icon: LockOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      x509_pem_file: {
+        icon: LockOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      bzip2_file: {
+        icon: FileZipOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      gzip_file: {
+        icon: FileZipOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      lzma_file: {
+        icon: FileZipOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      xz_file: {
+        icon: FileZipOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      zlib_file: {
+        icon: FileZipOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      doc_subheader_file: {
+        icon: FileWordOutlined,
+        color: token.geekblue,
+        name: 'geekblue',
+      },
+      excel4_file: {
+        icon: FileExcelOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      iqy_file: {
+        icon: FileExcelOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      onenote_file: {
+        icon: FileWordOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      mso_file: {
+        icon: FileTextOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      olecf_file: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      ooxml_file: {
+        icon: FileTextOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      pdf_file: {
+        icon: FilePdfOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      poi_hpbf_file: {
+        icon: FileTextOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      rtf_file: {
+        icon: FileTextOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      vbframe_file: {
+        icon: CodeOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      wordml_file: {
+        icon: FileWordOutlined,
+        color: token.geekblue,
+        name: 'geekblue',
+      },
+      xfdf_file: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      email_file: {
+        icon: MailOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      tnef_file: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      base64_pe: {
+        icon: CodeOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      pgp_file: {
+        icon: LockOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      elf_file: {
+        icon: PlaySquareOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      lnk_file: {
+        icon: FileOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      macho_file: {
+        icon: PlaySquareOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      mz_file: {
+        icon: PlaySquareOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      bmp_file: {
+        icon: PictureOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      cmap_file: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      gif_file: {
+        icon: FileGifOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      jpeg_file: {
+        icon: PictureOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      postscript_file: {
+        icon: FileTextOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      png_file: {
+        icon: PictureOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      psd_file: {
+        icon: FileImageOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      psd_image_file: {
+        icon: FileImageOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      svg_file: {
+        icon: FileImageOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      xicc_file: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      xmp_file: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      jar_manifest_file: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      bplist_file: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      fws_file: {
+        icon: PlaySquareOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      cws_file: {
+        icon: PlaySquareOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      zws_file: {
+        icon: PlaySquareOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      debian_package_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      rpm_file: {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      hacktool_win_shellcode_donut: {
+        icon: CodeOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      upx_file: {
+        icon: FileZipOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      batch_file: {
+        icon: CodeOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      javascript_file: {
+        icon: CodeOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      vb_file: {
+        icon: CodeOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      hta_file: {
+        icon: CodeOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      html_file: {
+        icon: Html5Outlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      ini_file: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      json_file: {
+        icon: FileOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      php_file: {
+        icon: CodeOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      plist_file: {
+        icon: FileTextOutlined,
+        color: DARK_GRAY,
+        name: 'default',
+      },
+      soap_file: {
+        icon: FileTextOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      xml_file: {
+        icon: FileTextOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      avi_file: {
+        icon: PlaySquareOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      wmv_file: {
+        icon: PlaySquareOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      credit_cards: {
+        icon: LockOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      vsto_file: {
+        icon: FileTextOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      // -----------
+      // Mime Types (Overridden by YARA Type, if exists)
+      // -----------
+      'application/octet-stream': {
+        icon: NumberOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      'text/plain': {
+        icon: FileTextOutlined,
+        color: GRAY,
+      },
+      'text/html': {
+        icon: Html5Outlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      'text/csv': {
+        icon: TableOutlined,
+        color: token.lime,
+        name: 'lime',
+      },
+      'image/png': {
+        icon: PictureOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      'image/jpeg': {
+        icon: PictureOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      'application/pdf': {
+        icon: FilePdfOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      'text/xml': {
+        icon: FileTextOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      'application/x-executable': {
+        icon: PlaySquareOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      'application/zip': {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      'application/vnd.ms-excel': {
+        icon: FileExcelOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': {
+        icon: FileExcelOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      'application/msword': {
+        icon: FileWordOutlined,
+        color: token.geekblue,
+        name: 'geekblue',
+      },
+      'application/x-dosexec': {
+        icon: PlaySquareOutlined,
+        color: token.red,
+        name: 'red',
+      },
+      'application/x-dbt': {
+        icon: DatabaseOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      'application/encrypted': {
+        icon: LockOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      'application/x-matlab-data': {
+        icon: CalculatorOutlined,
+        color: token.yellow,
+        name: 'yellow',
+      },
+      'application/x-pnf': {
+        icon: FileOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      'application/x-empty': {
+        icon: FileUnknownOutlined,
+        color: GRAY,
+      },
+      'application/cdfv2': {
+        icon: FileTextOutlined,
+        color: GRAY,
+      },
+      'application/gzip': {
+        icon: FileZipOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      'image/svg+xml': {
+        icon: FileImageOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      'message/rfc822': {
+        icon: MailOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      'text/rtf': {
+        icon: FileWordOutlined,
+        color: token.green,
+        name: 'green',
+      },
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+        {
+          icon: FileWordOutlined,
+          color: token.green,
+          name: 'green',
+        },
+      'application/x-wine-extension-ini': {
+        icon: ExperimentOutlined,
+        color: token.magenta,
+        name: 'magenta',
+      },
+      'application/x-setupscript': {
+        icon: CodeOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      'text/css': {
+        icon: CodeOutlined,
+        color: token.cyan,
+        name: 'cyan',
+      },
+      'application/json': {
+        icon: FileOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      'application/xml': {
+        icon: FileOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      'application/javascript': {
+        icon: CodeOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+      'text/markdown': {
+        icon: FileMarkdownOutlined,
+        color: token.lime,
+        name: 'lime',
+      },
+      'image/gif': {
+        icon: FileGifOutlined,
+        color: token.gold,
+        name: 'gold',
+      },
+      domain: {
+        icon: GlobalOutlined,
+        color: token.blue,
+        name: 'blue',
+      },
+      url: {
+        icon: LinkOutlined,
+        color: token.geekblue,
+        name: 'geekblue',
+      },
+      md5: {
+        icon: SafetyCertificateOutlined,
+        color: token.purple5,
+        name: 'purple',
+      },
+      sha1: {
+        icon: SafetyCertificateOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      sha256: {
+        icon: SafetyCertificateOutlined,
+        color: token.purple,
+        name: 'purple',
+      },
+      ip: {
+        icon: NumberOutlined,
+        color: token.orange,
+        name: 'orange',
+      },
+    }),
+    [token],
+  )
+
+  // Function to get icon configuration
+  const getIconConfig = useCallback(
+    (category, type) => {
+      if (category !== 'strelka') {
+        return flowIconMappingTable.defaultIcon
+      }
+
+      const iconConfig =
+        flowIconMappingTable[type] || flowIconMappingTable.defaultIcon
+      return iconConfig
+    },
+    [flowIconMappingTable],
+  )
+
+  return {
+    getIconConfig,
+    icons: flowIconMappingTable,
   }
-  return defaultIconConfig
 }

--- a/ui/src/utils/layoutUtils.ts
+++ b/ui/src/utils/layoutUtils.ts
@@ -1,6 +1,5 @@
 import type { Edge, Node } from '@xyflow/react'
 import type { StrelkaResponse } from '../services/api.types'
-import { getIconConfig } from './iconMappingTable'
 import {
   type StrelkaNodeData,
   indexDataType,
@@ -76,6 +75,7 @@ export const toggleChildrenVisibility = (
 
 export function transformElasticSearchDataToElements(
   results: StrelkaResponse[],
+  getIconConfig: (type: string, subtype: string) => { color: string },
 ) {
   const nodes: Node<StrelkaNodeData>[] = []
   const edges: Edge[] = []


### PR DESCRIPTION
This PR makes updates the colors to leverage the antd theme tokens. This should correct a lot of the dark/light theme contrast issues. There are a few other tweaks for readability that were made as well.

Most of the changes are captured in the before/after image below.
(along with a couple of screenshot artifacts... ignore those 😄 )
![Untitled (3)](https://github.com/user-attachments/assets/b58ad48c-7645-4e89-9054-a0b3677ab435)
